### PR TITLE
chore: update depn & bump version for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-twitter",
-  "version": "1.0.0-beta.54",
+  "version": "1.0.0-beta.55",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -18,7 +18,7 @@
     "dist"
   ],
   "dependencies": {
-    "@elizaos/core": "^1.0.0-beta.69",
+    "@elizaos/core": "^1.0.0-beta",
     "@roamhq/wrtc": "^0.8.0",
     "@sinclair/typebox": "^0.32.20",
     "glob": "11.0.0",


### PR DESCRIPTION
Updating to latest `@elizaos/core`. 

Bump the version to trigger the release. 