### PR TITLE
Fix: Respect 'following' timeline mode on timeline population

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -15,6 +15,7 @@ import {
   type Tweet,
 } from "./client/index";
 import { TwitterInteractionPayload } from "./types";
+import { TIMELINE_TYPE } from "./timeline";
 
 interface TwitterUser {
   id_str: string;
@@ -675,7 +676,11 @@ export class ClientBase {
       }
     }
 
-    const timeline = await this.fetchHomeTimeline(cachedTimeline ? 10 : 50);
+    const following =
+      (this.state?.TWITTER_TIMELINE_MODE ||
+       this.runtime.getSetting("TWITTER_TIMELINE_MODE"))
+      === TIMELINE_TYPE.Following;
+    const timeline = await this.fetchHomeTimeline(cachedTimeline ? 10 : following ? 20 : 50, following);
     const username = this.runtime.getSetting("TWITTER_USERNAME");
 
     // Get the most recent 20 mentions and interactions

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -17,6 +17,7 @@ export const twitterEnvSchema = z.object({
   TWITTER_RETRY_LIMIT: z.number().int(),
   TWITTER_POLL_INTERVAL: z.number().int(),
   TWITTER_TARGET_USERS: z.string().default(""),
+  TWITTER_TIMELINE_MODE: z.string().refine(val => !val || val === 'following' || val === 'foryou', 'Timeline mode must be either "following", "foryou", or empty'),
   TWITTER_ENABLE_POST_GENERATION: z.boolean(),
   TWITTER_POST_INTERVAL_MIN: z.number().int(),
   TWITTER_POST_INTERVAL_MAX: z.number().int(),
@@ -127,6 +128,12 @@ export async function validateTwitterConfig(
       TWITTER_TARGET_USERS:
         runtime.getSetting("TWITTER_TARGET_USERS") ||
         process.env.TWITTER_TARGET_USERS ||
+        "",
+      
+      //string - 'following' or 'foryou' (or empty => default to 'foryou')
+      TWITTER_TIMELINE_MODE:
+        runtime.getSetting("TWITTER_TIMELINE_MODE") ||
+        process.env.TWITTER_TIMELINE_MODE ||
         "",
 
       // bool

--- a/src/timeline.ts
+++ b/src/timeline.ts
@@ -21,7 +21,7 @@ import {
 import { sendTweet, parseActionResponseFromText } from "./utils";
 import { ActionResponse } from "./types";
 
-enum TIMELINE_TYPE {
+export enum TIMELINE_TYPE {
   ForYou = "foryou",
   Following = "following",
 }


### PR DESCRIPTION
Use `TWITTER_TIMELINE_MODE='following'` during the first timeline population, and limit the entries to 20 when it's set to 'following'.

Also add some parsing, although it doesn't seem to be used...  🤷‍♂️