### PR TITLE
Limit processed tweets

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -15,6 +15,7 @@ import {
   type Tweet,
 } from "./client/index";
 import { TwitterInteractionPayload } from "./types";
+import { TIMELINE_TYPE } from "./timeline";
 
 interface TwitterUser {
   id_str: string;
@@ -675,7 +676,11 @@ export class ClientBase {
       }
     }
 
-    const timeline = await this.fetchHomeTimeline(cachedTimeline ? 10 : 50);
+    const following =
+      (this.state?.TWITTER_TIMELINE_MODE ||
+       this.runtime.getSetting("TWITTER_TIMELINE_MODE"))
+      === TIMELINE_TYPE.Following;
+    const timeline = await this.fetchHomeTimeline(cachedTimeline ? 10 : following ? 20 : 50, following);
     const username = this.runtime.getSetting("TWITTER_USERNAME");
 
     // Get the most recent 20 mentions and interactions

--- a/src/base.ts
+++ b/src/base.ts
@@ -246,7 +246,7 @@ export class ClientBase {
       conversationId: raw.conversationId ?? raw.legacy?.conversation_id_str,
       hashtags: raw.hashtags ?? raw.legacy?.entities?.hashtags ?? [],
       html: raw.html,
-      id: raw.id ?? raw.rest_id ?? raw.legacy.id_str ?? raw.id_str ?? undefined,
+      id: raw.id ?? raw.rest_id ?? raw.legacy?.id_str ?? raw.id_str ?? undefined,
       inReplyToStatus: raw.inReplyToStatus,
       inReplyToStatusId:
         raw.inReplyToStatusId ??
@@ -274,7 +274,7 @@ export class ClientBase {
         (raw.legacy?.entities?.media
           ?.filter((media: any) => media.type === "photo")
           .map((media: any) => ({
-            id: media.id_str || media.rest_id || media.legacy.id_str,
+            id: media.id_str || media.rest_id || media.legacy?.id_str,
             url: media.media_url_https,
             alt_text: media.alt_text,
           })) ||
@@ -299,7 +299,7 @@ export class ClientBase {
       timestamp:
         raw.timestamp ??
         (raw.legacy?.created_at
-          ? new Date(raw.legacy.created_at).getTime() / 1000
+          ? new Date(raw.legacy?.created_at).getTime() / 1000
           : undefined),
       urls: raw.urls ?? raw.legacy?.entities?.urls ?? [],
       userId: raw.userId ?? raw.legacy?.user_id_str ?? undefined,
@@ -313,7 +313,7 @@ export class ClientBase {
           (media: any) => media.type === "video"
         ) ??
         [],
-      views: raw.views?.count ? Number(raw.views.count) : 0,
+      views: raw.views?.count ? Number(raw.views?.count) : 0,
       sensitiveContent: raw.sensitiveContent,
     };
 

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -17,6 +17,7 @@ export const twitterEnvSchema = z.object({
   TWITTER_RETRY_LIMIT: z.number().int(),
   TWITTER_POLL_INTERVAL: z.number().int(),
   TWITTER_TARGET_USERS: z.string().default(""),
+  TWITTER_TIMELINE_MODE: z.string().refine(val => !val || val === 'following' || val === 'foryou', 'Timeline mode must be either "following", "foryou", or empty'),
   TWITTER_ENABLE_POST_GENERATION: z.boolean(),
   TWITTER_POST_INTERVAL_MIN: z.number().int(),
   TWITTER_POST_INTERVAL_MAX: z.number().int(),
@@ -127,6 +128,12 @@ export async function validateTwitterConfig(
       TWITTER_TARGET_USERS:
         runtime.getSetting("TWITTER_TARGET_USERS") ||
         process.env.TWITTER_TARGET_USERS ||
+        "",
+      
+      //string - 'following' or 'foryou' (or empty => default to 'foryou')
+      TWITTER_TIMELINE_MODE:
+        runtime.getSetting("TWITTER_TIMELINE_MODE") ||
+        process.env.TWITTER_TIMELINE_MODE ||
         "",
 
       // bool

--- a/src/timeline.ts
+++ b/src/timeline.ts
@@ -21,7 +21,7 @@ import {
 import { sendTweet, parseActionResponseFromText } from "./utils";
 import { ActionResponse } from "./types";
 
-enum TIMELINE_TYPE {
+export enum TIMELINE_TYPE {
   ForYou = "foryou",
   Following = "following",
 }


### PR DESCRIPTION
Added `TWITTER_MAX_ACTIONS_BATCH_SIZE` to limit how many tweets are being processed in the timeline.

It seems like the 'count' that's passed into the twitter API doesn't actually work (defaults to 20, but I often get more tweets (100)). 

There was already a variable which I assume was supposed to serve the same purpose, but not actually used. 